### PR TITLE
Refactor minimal APIs into controllers

### DIFF
--- a/src/UdemyClone.Api/Controllers/AuthController.cs
+++ b/src/UdemyClone.Api/Controllers/AuthController.cs
@@ -1,0 +1,37 @@
+using BCrypt.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using UdemyClone.Api.Data;
+using UdemyClone.Api.Domain;
+using UdemyClone.Api.DTOs;
+
+namespace UdemyClone.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly ApplicationDbContext _db;
+
+    public AuthController(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] RegisterRequest req)
+    {
+        if (await _db.Users.AnyAsync(u => u.Email == req.Email))
+            return BadRequest("Email zaten kayıtlı.");
+
+        var user = new User
+        {
+            Email = req.Email,
+            SifreHash = BCrypt.Net.BCrypt.HashPassword(req.Password),
+            Rol = string.IsNullOrWhiteSpace(req.Role) ? UserRoles.Student : req.Role!
+        };
+        _db.Users.Add(user);
+        await _db.SaveChangesAsync();
+        return Created($"/api/users/{user.Id}", new { user.Id, user.Email, user.Rol });
+    }
+}

--- a/src/UdemyClone.Api/Controllers/CouponsController.cs
+++ b/src/UdemyClone.Api/Controllers/CouponsController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using UdemyClone.Api.Application.UseCases;
+using UdemyClone.Api.DTOs;
+
+namespace UdemyClone.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CouponsController : ControllerBase
+{
+    private readonly CreateCouponUseCase _useCase;
+
+    public CouponsController(CreateCouponUseCase useCase)
+    {
+        _useCase = useCase;
+    }
+
+    [Authorize]
+    [HttpPost]
+    public async Task<IActionResult> CreateCoupon([FromBody] CreateCouponRequest req)
+    {
+        var sub = User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!int.TryParse(sub, out var instructorId))
+            return Unauthorized();
+
+        var (success, error, coupon) = await _useCase.ExecuteAsync(instructorId, req);
+        return success
+            ? Created($"/api/coupons/{coupon!.Id}", coupon)
+            : BadRequest(error);
+    }
+}

--- a/src/UdemyClone.Api/Controllers/CoursesController.cs
+++ b/src/UdemyClone.Api/Controllers/CoursesController.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using UdemyClone.Api.Data;
+using UdemyClone.Api.Domain;
+using UdemyClone.Api.DTOs;
+using UdemyClone.Api.Services;
+
+namespace UdemyClone.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CoursesController : ControllerBase
+{
+    private readonly ApplicationDbContext _db;
+    private readonly ICommentService _commentService;
+
+    public CoursesController(ApplicationDbContext db, ICommentService commentService)
+    {
+        _db = db;
+        _commentService = commentService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateCourse([FromBody] CreateCourseRequest req)
+    {
+        var instructor = await _db.Users.FindAsync(req.InstructorId);
+        if (instructor is null || instructor.Rol != UserRoles.Instructor)
+            return BadRequest("Geçersiz eğitmen.");
+        var kategori = await _db.Categories.FindAsync(req.CategoryId);
+        if (kategori is null) return BadRequest("Geçersiz kategori.");
+
+        var course = new Course
+        {
+            Baslik = req.Title,
+            Aciklama = req.Description,
+            Fiyat = req.Price,
+            EgitmenId = req.InstructorId,
+            KategoriId = req.CategoryId,
+            YayindaMi = req.Published
+        };
+        _db.Courses.Add(course);
+        await _db.SaveChangesAsync();
+        return Created($"/api/courses/{course.Id}", course);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetCourses([FromQuery] int? categoryId, [FromQuery] string? q)
+    {
+        var query = _db.Courses
+            .Include(c => c.Kategori)
+            .Include(c => c.Egitmen)
+            .AsQueryable();
+
+        if (categoryId.HasValue) query = query.Where(c => c.KategoriId == categoryId.Value);
+        if (!string.IsNullOrWhiteSpace(q)) query = query.Where(c => c.Baslik.Contains(q));
+
+        var data = await query
+            .Select(c => new
+            {
+                c.Id,
+                c.Baslik,
+                c.Fiyat,
+                Category = c.Kategori!.Ad,
+                Instructor = c.Egitmen!.Email,
+                Lessons = c.Dersler.Count
+            }).ToListAsync();
+
+        return Ok(data);
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetCourse(int id)
+    {
+        var course = await _db.Courses
+            .Include(c => c.Kategori)
+            .Include(c => c.Egitmen)
+            .Include(c => c.Dersler)
+            .FirstOrDefaultAsync(c => c.Id == id);
+        return course is null ? NotFound() : Ok(course);
+    }
+
+    [HttpPost("{id:int}/lessons")]
+    public async Task<IActionResult> AddLesson(int id, [FromBody] AddLessonRequest req)
+    {
+        var course = await _db.Courses.FindAsync(id);
+        if (course is null) return NotFound();
+
+        var lesson = new Lesson
+        {
+            KursId = id,
+            Baslik = req.Title,
+            IcerikUrl = req.ContentUrl,
+            SureSaniye = req.DurationSeconds
+        };
+        _db.Lessons.Add(lesson);
+        await _db.SaveChangesAsync();
+        return Created($"/api/courses/{id}/lessons/{lesson.Id}", lesson);
+    }
+
+    [Authorize]
+    [HttpPost("{courseId:int}/comments")]
+    public async Task<IActionResult> AddComment(int courseId, string content, int rating)
+    {
+        var sub = User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!int.TryParse(sub, out var authorId)) return Unauthorized();
+        var (ok, err, comment) = await _commentService.AddCommentAsync(authorId, courseId, content, rating);
+        return ok
+            ? Created($"/api/courses/{courseId}/comments/{comment!.Id}", comment)
+            : BadRequest(err);
+    }
+}

--- a/src/UdemyClone.Api/Controllers/EnrollmentsController.cs
+++ b/src/UdemyClone.Api/Controllers/EnrollmentsController.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using UdemyClone.Api.DTOs;
+using UdemyClone.Api.Services;
+
+namespace UdemyClone.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class EnrollmentsController : ControllerBase
+{
+    private readonly IEnrollmentService _svc;
+
+    public EnrollmentsController(IEnrollmentService svc)
+    {
+        _svc = svc;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Enroll([FromBody] EnrollRequest req)
+    {
+        var (ok, err, enr) = await _svc.EnrollAsync(req.UserId, req.CourseId);
+        return ok
+            ? Created($"/api/enrollments/{enr!.Id}", enr)
+            : BadRequest(err);
+    }
+}

--- a/src/UdemyClone.Api/Controllers/InstructorsController.cs
+++ b/src/UdemyClone.Api/Controllers/InstructorsController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using UdemyClone.Api.Data;
+
+namespace UdemyClone.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class InstructorsController : ControllerBase
+{
+    private readonly ApplicationDbContext _db;
+
+    public InstructorsController(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    [HttpGet("{instructorId:int}/courses")]
+    public async Task<IActionResult> GetCourses(int instructorId)
+    {
+        var data = await _db.Courses
+            .Where(c => c.EgitmenId == instructorId)
+            .Select(c => new { c.Id, c.Baslik, c.YayindaMi })
+            .ToListAsync();
+        return Ok(data);
+    }
+}

--- a/src/UdemyClone.Api/Controllers/LessonsController.cs
+++ b/src/UdemyClone.Api/Controllers/LessonsController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using UdemyClone.Api.Services;
+
+namespace UdemyClone.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class LessonsController : ControllerBase
+{
+    private readonly ILessonCompletionService _svc;
+
+    public LessonsController(ILessonCompletionService svc)
+    {
+        _svc = svc;
+    }
+
+    [Authorize]
+    [HttpPost("{lessonId:int}/complete")]
+    public async Task<IActionResult> Complete(int lessonId)
+    {
+        var sub = User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!int.TryParse(sub, out var userId)) return Unauthorized();
+        var (ok, err, comp) = await _svc.MarkCompletedAsync(userId, lessonId);
+        return ok
+            ? Created($"/api/lessons/{lessonId}/complete/{comp!.Id}", comp)
+            : BadRequest(err);
+    }
+}

--- a/src/UdemyClone.Api/Controllers/MessagesController.cs
+++ b/src/UdemyClone.Api/Controllers/MessagesController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using UdemyClone.Api.Services;
+
+namespace UdemyClone.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class MessagesController : ControllerBase
+{
+    private readonly IMessageService _svc;
+
+    public MessagesController(IMessageService svc)
+    {
+        _svc = svc;
+    }
+
+    [Authorize]
+    [HttpPost]
+    public async Task<IActionResult> SendMessage(int recipientId, string title, string content)
+    {
+        var sub = User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!int.TryParse(sub, out var senderId))
+            return Unauthorized();
+
+        var (ok, err, msg) = await _svc.SendMessageAsync(senderId, recipientId, title, content);
+        return ok
+            ? Created($"/api/messages/{msg!.Id}", msg)
+            : BadRequest(err);
+    }
+}

--- a/src/UdemyClone.Api/Controllers/UsersController.cs
+++ b/src/UdemyClone.Api/Controllers/UsersController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using UdemyClone.Api.Data;
+
+namespace UdemyClone.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly ApplicationDbContext _db;
+
+    public UsersController(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    [HttpGet("{userId:int}/courses")]
+    public async Task<IActionResult> GetCourses(int userId)
+    {
+        var data = await _db.Enrollments
+            .Where(e => e.UserId == userId)
+            .Select(e => new { e.Course!.Id, e.Course.Baslik, e.EnrolledAt })
+            .ToListAsync();
+        return Ok(data);
+    }
+}

--- a/src/UdemyClone.Api/Program.cs
+++ b/src/UdemyClone.Api/Program.cs
@@ -1,21 +1,17 @@
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using System.Text;
-using BCrypt.Net;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using UdemyClone.Api.Data;
-using UdemyClone.Api.Domain;
-using UdemyClone.Api.DTOs;
-using UdemyClone.Api.Application.UseCases;
 using UdemyClone.Api.Infrastructure.Repositories;
+using UdemyClone.Api.Application.UseCases;
 using UdemyClone.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Services
+builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {
@@ -37,14 +33,17 @@ builder.Services.AddSwaggerGen(options =>
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.SecurityScheme,
-                    Id = "Bearer"
+                    Id = "Bearer",
                 }
             },
             Array.Empty<string>()
         }
     });
 });
- builder.Services.ConfigureHttpJsonOptions(options =>  {   options.SerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles;  });
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles;
+});
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
@@ -68,13 +67,13 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddAuthorization();
 // Repositories and services
-builder.Services.AddScoped(typeof(UdemyClone.Api.Infrastructure.Repositories.IGenericRepository<>), typeof(UdemyClone.Api.Infrastructure.Repositories.EfGenericRepository<>));
-builder.Services.AddScoped<UdemyClone.Api.Application.UseCases.CreateCouponUseCase>();
+builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(EfGenericRepository<>));
+builder.Services.AddScoped<CreateCouponUseCase>();
 // Application services
-builder.Services.AddScoped<UdemyClone.Api.Services.IMessageService, UdemyClone.Api.Services.MessageService>();
-builder.Services.AddScoped<UdemyClone.Api.Services.ICommentService, UdemyClone.Api.Services.CommentService>();
-builder.Services.AddScoped<UdemyClone.Api.Services.IEnrollmentService, UdemyClone.Api.Services.EnrollmentService>();
-builder.Services.AddScoped<UdemyClone.Api.Services.ILessonCompletionService, UdemyClone.Api.Services.LessonCompletionService>();
+builder.Services.AddScoped<IMessageService, MessageService>();
+builder.Services.AddScoped<ICommentService, CommentService>();
+builder.Services.AddScoped<IEnrollmentService, EnrollmentService>();
+builder.Services.AddScoped<ILessonCompletionService, LessonCompletionService>();
 
 var app = builder.Build();
 
@@ -104,191 +103,6 @@ if (app.Environment.IsDevelopment())
 app.UseAuthentication();
 app.UseAuthorization();
 
-// Coupons endpoints
-var coupons = app.MapGroup("/coupons");
-
-coupons.MapPost("/", async (CreateCouponUseCase useCase, HttpContext http, CreateCouponRequest req) =>
-{
-    if (!http.User.Identity?.IsAuthenticated ?? true) return Results.Unauthorized();
-    var sub = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? http.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-    if (!int.TryParse(sub, out var instructorId)) return Results.Unauthorized();
-
-    var (success, error, coupon) = await useCase.ExecuteAsync(instructorId, req);
-    return success ? Results.Created($"/coupons/{coupon!.Id}", coupon) : Results.BadRequest(error);
-}).RequireAuthorization();
-
-// Auth endpoints
-var auth = app.MapGroup("/auth");
-
-// Auth endpoints - Register
-auth.MapPost("/register", async (ApplicationDbContext db, RegisterRequest req) =>
-{
-    if (await db.Users.AnyAsync(u => u.Email == req.Email))
-        return Results.BadRequest("Email zaten kayıtlı.");
-
-    var user = new User
-    {
-        Email = req.Email,
-        SifreHash = BCrypt.Net.BCrypt.HashPassword(req.Password),
-        Rol = string.IsNullOrWhiteSpace(req.Role) ? UserRoles.Student : req.Role!
-    };
-    db.Users.Add(user);
-    await db.SaveChangesAsync();
-    return Results.Created($"/users/{user.Id}", new { user.Id, user.Email, user.Rol });
-});
-
-// Auth endpoints - Login remains unchanged
-
-// Messaging
-app.MapPost("/messages", async (IMessageService svc, HttpContext http, int recipientId, string title, string content) =>
-{
-    if (!http.User.Identity?.IsAuthenticated ?? true) return Results.Unauthorized();
-    var sub = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? http.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-    if (!int.TryParse(sub, out var senderId)) return Results.Unauthorized();
-    var (ok, err, msg) = await svc.SendMessageAsync(senderId, recipientId, title, content);
-    return ok ? Results.Created($"/messages/{msg!.Id}", msg) : Results.BadRequest(err);
-}).RequireAuthorization();
-
-// Comments
-app.MapPost("/courses/{courseId:int}/comments", async (ICommentService svc, HttpContext http, int courseId, string content, int rating) =>
-{
-    if (!http.User.Identity?.IsAuthenticated ?? true) return Results.Unauthorized();
-    var sub = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? http.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-    if (!int.TryParse(sub, out var authorId)) return Results.Unauthorized();
-    var (ok, err, comment) = await svc.AddCommentAsync(authorId, courseId, content, rating);
-    return ok ? Results.Created($"/courses/{courseId}/comments/{comment!.Id}", comment) : Results.BadRequest(err);
-}).RequireAuthorization();
-
-// Enrollment (wraps existing logic)
-app.MapPost("/enrollments", async (IEnrollmentService svc, EnrollRequest req) =>
-{
-    var (ok, err, enr) = await svc.EnrollAsync(req.UserId, req.CourseId);
-    return ok ? Results.Created($"/enrollments/{enr!.Id}", enr) : Results.BadRequest(err);
-});
-
-// Lesson completion
-app.MapPost("/lessons/{lessonId:int}/complete", async (ILessonCompletionService svc, HttpContext http, int lessonId) =>
-{
-    if (!http.User.Identity?.IsAuthenticated ?? true) return Results.Unauthorized();
-    var sub = http.User.FindFirst(JwtRegisteredClaimNames.Sub)?.Value ?? http.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-    if (!int.TryParse(sub, out var userId)) return Results.Unauthorized();
-    var (ok, err, comp) = await svc.MarkCompletedAsync(userId, lessonId);
-    return ok ? Results.Created($"/lessons/{lessonId}/complete/{comp!.Id}", comp) : Results.BadRequest(err);
-}).RequireAuthorization();
-
-// Courses endpoints
-var courses = app.MapGroup("/courses");
-
-// Courses endpoints - Create course endpoint
-courses.MapPost("/", async (ApplicationDbContext db, CreateCourseRequest req) =>
-{
-    var instructor = await db.Users.FindAsync(req.InstructorId);
-    if (instructor is null || instructor.Rol != UserRoles.Instructor)
-        return Results.BadRequest("Geçersiz eğitmen.");
-    var kategori = await db.Categories.FindAsync(req.CategoryId);
-    if (kategori is null) return Results.BadRequest("Geçersiz kategori.");
-
-    var course = new Course
-    {
-        Baslik = req.Title,
-        Aciklama = req.Description,
-        Fiyat = req.Price,
-        EgitmenId = req.InstructorId,
-        KategoriId = req.CategoryId,
-        YayindaMi = req.Published
-    };
-    db.Courses.Add(course);
-    await db.SaveChangesAsync();
-    return Results.Created($"/courses/{course.Id}", course);
-});
-
-// Courses endpoints - Get courses mapping
-courses.MapGet("/", async (ApplicationDbContext db, int? categoryId, string? q) =>
-{
-    var query = db.Courses
-        .Include(c => c.Kategori)
-        .Include(c => c.Egitmen)
-        .AsQueryable();
-
-    if (categoryId.HasValue) query = query.Where(c => c.KategoriId == categoryId.Value);
-    if (!string.IsNullOrWhiteSpace(q)) query = query.Where(c => c.Baslik.Contains(q));
-
-    var data = await query
-        .Select(c => new
-        {
-            c.Id,
-            c.Baslik,
-            c.Fiyat,
-            Category = c.Kategori!.Ad,
-            Instructor = c.Egitmen!.Email,
-            Lessons = c.Dersler.Count
-        }).ToListAsync();
-
-    return Results.Ok(data);
-});
-
-// Courses endpoints - Get course detail
-courses.MapGet("/{id:int}", async (ApplicationDbContext db, int id) =>
-{
-    var course = await db.Courses
-        .Include(c => c.Kategori)
-        .Include(c => c.Egitmen)
-        .Include(c => c.Dersler)
-        .FirstOrDefaultAsync(c => c.Id == id);
-    return course is null ? Results.NotFound() : Results.Ok(course);
-});
-
-// Lessons endpoint - Create lesson for a course
-courses.MapPost("/{id:int}/lessons", async (ApplicationDbContext db, int id, AddLessonRequest req) =>
-{
-    var course = await db.Courses.FindAsync(id);
-    if (course is null) return Results.NotFound();
-
-    var lesson = new Lesson
-    {
-        KursId = id,
-        Baslik = req.Title,
-        IcerikUrl = req.ContentUrl,
-        SureSaniye = req.DurationSeconds
-    };
-    db.Lessons.Add(lesson);
-    await db.SaveChangesAsync();
-    return Results.Created($"/courses/{id}/lessons/{lesson.Id}", lesson);
-});
-
-// Enrollment endpoints
-var enrollments = app.MapGroup("/enrollments");
-enrollments.MapPost("/", async (ApplicationDbContext db, EnrollRequest req) =>
-{
-    var user = await db.Users.FindAsync(req.UserId);
-    var course = await db.Courses.FindAsync(req.CourseId);
-    if (user is null || course is null) return Results.BadRequest("Geçersiz kullanıcı veya kurs.");
-    if (await db.Enrollments.AnyAsync(e => e.UserId == req.UserId && e.CourseId == req.CourseId))
-        return Results.Conflict("Zaten kayıtlısınız.");
-
-    var enr = new Enrollment { UserId = req.UserId, CourseId = req.CourseId, EnrolledAt = DateTime.UtcNow };
-    db.Enrollments.Add(enr);
-    await db.SaveChangesAsync();
-    return Results.Created($"/enrollments/{enr.Id}", enr);
-});
-
-app.MapGet("/users/{userId:int}/courses", async (ApplicationDbContext db, int userId) =>
-{
-    var data = await db.Enrollments
-        .Where(e => e.UserId == userId)
-        .Select(e => new { e.Course!.Id, e.Course.Baslik, e.EnrolledAt })
-        .ToListAsync();
-    return Results.Ok(data);
-});
-
-app.MapGet("/instructors/{instructorId:int}/courses", async (ApplicationDbContext db, int instructorId) =>
-{
-    var data = await db.Courses
-        .Where(c => c.EgitmenId == instructorId)
-        .Select(c => new { c.Id, c.Baslik, c.YayindaMi })
-        .ToListAsync();
-    return Results.Ok(data);
-});
+app.MapControllers();
 
 app.Run();
-


### PR DESCRIPTION
## Summary
- Replace minimal API mappings with MVC controllers for coupons, auth, messages, courses, enrollments, lessons, users, and instructors
- Configure Program.cs to support controllers with AddControllers and MapControllers

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b18efe22e48333b22909cba57a1b9c