### PR TITLE
Add login endpoint with JWT generation

### DIFF
--- a/src/UdemyClone.Api/Controllers/AuthController.cs
+++ b/src/UdemyClone.Api/Controllers/AuthController.cs
@@ -1,6 +1,11 @@
 using BCrypt.Net;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
 using UdemyClone.Api.Data;
 using UdemyClone.Api.Domain;
 using UdemyClone.Api.DTOs;
@@ -12,10 +17,12 @@ namespace UdemyClone.Api.Controllers;
 public class AuthController : ControllerBase
 {
     private readonly ApplicationDbContext _db;
+    private readonly IConfiguration _configuration;
 
-    public AuthController(ApplicationDbContext db)
+    public AuthController(ApplicationDbContext db, IConfiguration configuration)
     {
         _db = db;
+        _configuration = configuration;
     }
 
     [HttpPost("register")]
@@ -33,5 +40,32 @@ public class AuthController : ControllerBase
         _db.Users.Add(user);
         await _db.SaveChangesAsync();
         return Created($"/api/users/{user.Id}", new { user.Id, user.Email, user.Rol });
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] LoginRequest req)
+    {
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Email == req.Email);
+        if (user is null || !BCrypt.Net.BCrypt.Verify(req.Password, user.SifreHash))
+            return Unauthorized();
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _configuration["Jwt:Issuer"],
+            audience: _configuration["Jwt:Audience"],
+            claims: new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                new Claim(ClaimTypes.Email, user.Email),
+                new Claim(ClaimTypes.Role, user.Rol)
+            },
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds
+        );
+
+        var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
+        return Ok(tokenString);
     }
 }


### PR DESCRIPTION
## Summary
- add POST /api/auth/login endpoint
- generate JWT token using configured settings

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 - repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1981158e483339b2989550f9e7ff1