### PR TITLE
Run migrations instead of recreating DB in development

### DIFF
--- a/src/UdemyClone.Api/Program.cs
+++ b/src/UdemyClone.Api/Program.cs
@@ -77,25 +77,23 @@ builder.Services.AddScoped<ILessonCompletionService, LessonCompletionService>();
 
 var app = builder.Build();
 
-// DB init (EnsureCreated for quick start)
-using (var scope = app.Services.CreateScope())
-{
-    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-    db.Database.EnsureDeleted(); // For development: delete existing database to apply new schema
-    db.Database.EnsureCreated();
-    if (!db.Set<UdemyClone.Api.Domain.Kategori>().Any())
-    {
-        db.Set<UdemyClone.Api.Domain.Kategori>().AddRange(
-            new UdemyClone.Api.Domain.Kategori { Ad = "Development" },
-            new UdemyClone.Api.Domain.Kategori { Ad = "Business" },
-            new UdemyClone.Api.Domain.Kategori { Ad = "Design" }
-        );
-        db.SaveChanges();
-    }
-}
-
 if (app.Environment.IsDevelopment())
 {
+    using (var scope = app.Services.CreateScope())
+    {
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.Database.Migrate();
+        if (!db.Set<UdemyClone.Api.Domain.Kategori>().Any())
+        {
+            db.Set<UdemyClone.Api.Domain.Kategori>().AddRange(
+                new UdemyClone.Api.Domain.Kategori { Ad = "Development" },
+                new UdemyClone.Api.Domain.Kategori { Ad = "Business" },
+                new UdemyClone.Api.Domain.Kategori { Ad = "Design" }
+            );
+            db.SaveChanges();
+        }
+    }
+
     app.UseSwagger();
     app.UseSwaggerUI();
 }


### PR DESCRIPTION
## Summary
- Run database initialization only in development
- Replace EnsureCreated with Migrate so schema updates apply without dropping data
- Remove automatic EnsureDeleted call to preserve existing database

## Testing
- ⚠️ `dotnet build` *(command not found: dotnet)*
- ⚠️ `apt-get update` *(403 Forbidden from proxy)*
- ⚠️ `apt-get install -y dotnet-sdk-7.0` *(Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b19fdfe4cc83338af2bee47abd51f7